### PR TITLE
Added in (simple) support for Jupyter comms_info_request client message

### DIFF
--- a/iracket.rkt
+++ b/iracket.rkt
@@ -9,6 +9,7 @@
          "private/iracket-execute.rkt"
          "private/iracket-connect.rkt"
          "private/iracket-kernel-info.rkt"
+         "private/iracket-comm-info.rkt"
          "private/iracket-complete.rkt"
          (prefix-in ipy: "private/ipython-message.rkt")
          (prefix-in ipy: "private/ipython-services.rkt")
@@ -46,6 +47,7 @@
    complete
    connect
    kernel-info
+   comm-info
    shutdown)
   #:transparent)
 
@@ -55,6 +57,7 @@
    (λ (msg) (complete e msg))
    (λ (_msg) (connect cfg))
    (λ (_msg) kernel-info)
+   (λ (_msg) comm-info)
    (λ (_msg) (hasheq 'restart #f))))
 
 (define (handle handlers msg)
@@ -62,6 +65,7 @@
   (define handler
     (case msg-type
       [(kernel_info_request) handlers-kernel-info]
+      [(comm_info_request) handlers-comm-info]
       [(connect_request) handlers-connect]
       [(execute_request) handlers-execute]
       [(complete_request) handlers-complete]

--- a/private/ipython-message.rkt
+++ b/private/ipython-message.rkt
@@ -15,6 +15,7 @@
 ;; Message types
 (define shell-in-message-type/c
   (symbols 'kernel_info_request
+	   'comm_info_request
            'execute_request
            'complete_request
            'object_info_request
@@ -23,6 +24,7 @@
 
 (define shell-out-message-type/c
   (symbols 'kernel_info_reply
+	   'comm_info_reply
            'execute_reply
            'complete_reply
            'object_info_reply
@@ -83,6 +85,7 @@
 (define (reply-type parent-type)
   (case parent-type
     [(kernel_info_request) 'kernel_info_reply]
+    [(comm_info_request) 'comm_info_reply]
     [(execute_request) 'execute_reply]
     [(complete_request) 'complete_reply]
     [(object_info_request) 'object_info_reply]

--- a/private/iracket-comm-info.rkt
+++ b/private/iracket-comm-info.rkt
@@ -3,6 +3,7 @@
 (provide comm-info)
 
 ;; comm_info_request
+;; replies with an empty dictionary for the comm_info_request
 (define comm-info
   (hasheq
    'comms ""))

--- a/private/iracket-comm-info.rkt
+++ b/private/iracket-comm-info.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(provide comm-info)
+
+;; comm_info_request
+(define comm-info
+  (hasheq
+   'comms ""))

--- a/private/iracket-comm-info.rkt
+++ b/private/iracket-comm-info.rkt
@@ -2,8 +2,23 @@
 
 (provide comm-info)
 
+;; comm_info_request / comm_info_reply
+;; A complete request / replyi template looks like:
 ;; comm_info_request
-;; replies with an empty dictionary for the comm_info_request
+;; content = {
+;;     # Optional, the target name
+;;     'target_name': str,
+;; }
+;; comm_info_reply
+;; content = {
+;;     # A dictionary of the comms, indexed by uuids.
+;;     'comms': {
+;;         comm_id: {
+;;             'target_name': str,
+;;         },
+;;     },
+;; }
+;;
+;; In this case, simply reply with an empty dictionary 
 (define comm-info
-  (hasheq
-   'comms ""))
+  (hasheq))


### PR DESCRIPTION
The latest Jupyter system has a new client message (comm_info_request) that isn’t currently handled. I’ve made some very simple changes that get iracket working again in Jupyter by simply returning an empty dictionary for this request message.