### PR TITLE
add #lang iracket/lang, support for configuring language

### DIFF
--- a/examples/scribble-reader-example.ipynb
+++ b/examples/scribble-reader-example.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#lang iracket/lang #:require racket/base #:reader scribble/reader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define xs @list[1 2 3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>6</code>"
+      ],
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(apply + xs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Racket",
+   "language": "racket",
+   "name": "racket"
+  },
+  "language_info": {
+   "codemirror_mode": "scheme",
+   "file_extension": ".rkt",
+   "mimetype": "text/x-racket",
+   "name": "Racket",
+   "pygments_lexer": "racket",
+   "version": "7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/typed-example.ipynb
+++ b/examples/typed-example.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#lang iracket/lang #:require typed/racket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(: f (-> Real Real))\n",
+    "(define (f x) (+ 2 (* x 3)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- : Real\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<code>14</code>"
+      ],
+      "text/plain": [
+       "14"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(f 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "eval:1:3: Type Checker: type mismatch\n",
+      "  expected: Real\n",
+      "  given: String\n",
+      "  in: \"hello\"\n",
+      "  location...:\n",
+      "   eval:1:3\n",
+      "  context...:\n",
+      "   do-raise-syntax-error\n",
+      "   /home/ryan/.local/racket-7.7/share/pkgs/typed-racket-lib/typed-racket/typecheck/check-below.rkt:122:5: perform-check!\n",
+      "   /home/ryan/.local/racket-7.7/share/pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt:366:0: single-value\n",
+      "   /home/ryan/.local/racket-7.7/share/pkgs/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt:110:12: for-loop\n",
+      "   parse-loop528\n",
+      "   fail-handler920\n",
+      "   fail-handler131\n",
+      "   /home/ryan/.local/racket-7.7/share/pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt:86:0: tc-expr/check\n",
+      "   /home/ryan/.local/racket-7.7/share/pkgs/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt:610:0: tc-toplevel-form\n",
+      "   fail-handler46\n",
+      "   apply-transformer-in-context\n",
+      "   apply-transformer\n",
+      "   dispatch-transformer\n",
+      "   expand-capturing-lifts\n",
+      "   loop\n",
+      "   /home/ryan/.local/racket-7.7/share/pkgs/sandbox-lib/racket/sandbox.rkt:510:0: call-with-custodian-shutdown\n",
+      "   ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "(f \"hello\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Racket",
+   "language": "racket",
+   "name": "racket"
+  },
+  "language_info": {
+   "codemirror_mode": "scheme",
+   "file_extension": ".rkt",
+   "mimetype": "text/x-racket",
+   "name": "Racket",
+   "pygments_lexer": "racket",
+   "version": "7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/info.rkt
+++ b/info.rkt
@@ -13,7 +13,8 @@
     "sha"))
 (define build-deps
   '("racket-doc"
-    "scribble-lib"))
+    "scribble-lib"
+    "scribble-doc"))
 
 ;; ========================================
 ;; collect info

--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,7 @@
 ;; ========================================
 ;; pkg info
 
-(define version "1.1")
+(define version "1.2")
 (define collection "iracket")
 (define deps
   '("base"

--- a/iracket.scrbl
+++ b/iracket.scrbl
@@ -131,10 +131,14 @@ Scribble's reader:
 @(require (for-label (only-in racket/list [range r:range])))
 @(define (r:range) @racketlink[r:range]{@racketfont{range}})
 
-Due to the combination of Racket's macro system, its recursive top-level
-environment, and the fact that the REPL receives and processes forms one at a
-time, the Racket REPL occasionally produces unexpected behavior. Consider the
-following program:
+Due to the combination of Racket's macro system, its recursive
+top-level environment, and the fact that the REPL receives and
+processes forms one at a time, the Racket REPL occasionally produces
+unexpected behavior. These problems are known in the Racket community
+as ``the top level is hopeless''. The same problems occur in Jupyter
+notebooks.
+
+For example, consider the following program:
 
 @racketblock[
 (code:comment "range : Real Real -> Real")

--- a/iracket.scrbl
+++ b/iracket.scrbl
@@ -99,6 +99,12 @@ If @racket[reader-mod] is given, the kernel's reader is set to the
 @racketidfont{read-syntax} export of @racket[reader-mod] (a module
 path); otherwise the kernel's reader is set to Racket's
 @racket[read-syntax].
+
+Warning: If @racket[reader-mod] is given, its @racketidfont{read-syntax} export
+must be suitable for reading top-level forms. For example,
+@racketmodname[scribble/reader] is suitable, but
+@racketmodname[at-exp/lang/reader] is not suitable, because it provides a
+@emph{whole-module meta-reader}.
 }
 
 If a cell contains @litchar{#lang iracket/lang}, it must be the first
@@ -161,6 +167,7 @@ To avoid this problem, avoid redefining names.
 (values))] before the definition above. This form of @racket[define-syntaxes] is
 only allowed at the top level, and it changes @racketidfont{range} to resolve as
 a binding in the top-level environment without giving it a value.)
+
 
 @subsection[#:tag "iracket-lang"]{@racket[#, @(hash-lang) #, @racketmodname[iracket/lang]]}
 

--- a/iracket.scrbl
+++ b/iracket.scrbl
@@ -71,3 +71,130 @@ to the currently running version of Racket is used.
 
 @history[#:added "1.1"]
 }
+
+
+@section[#:tag "lang"]{IRacket and Languages}
+
+The IRacket kernel does not support Racket's @(hash-lang) syntax for selecting
+languages, for the same reason that syntax doesn't work at the Racket REPL. That
+is, @(hash-lang) is a syntax for @emph{whole modules}, whereas both the REPL and
+Jupyter work with top-level forms and generally receive them one at a time. See
+also @secref["hopeless"].
+
+Instead of general @(hash-lang) support, IRacket recognizes
+@litchar{#lang iracket/lang} as a special declaration for adjusting
+the notebook's language.
+
+@specform[(code:line #, @litchar{#lang iracket/lang} #:require lang-mod maybe-reader)
+          #:grammar
+          ([maybe-reader (code:line) (code:line #:reader reader-mod)])]{
+
+Creates a new empty namespace, populates it by requiring
+@racket[lang-mod] (a module path), and installs it as the kernel's
+current namespace, used for evaluation. The namespace shares the
+module instances of the kernel's original namespace, but it does not
+include previous top-level definitions.
+
+If @racket[reader-mod] is given, the kernel's reader is set to the
+@racketidfont{read-syntax} export of @racket[reader-mod] (a module
+path); otherwise the kernel's reader is set to Racket's
+@racket[read-syntax].
+}
+
+If a cell contains @litchar{#lang iracket/lang}, it must be the first
+thing in the cell; no other forms, comments, or even whitespace can
+appear before it. The declaration does not have to appear in the first
+cell in the notebook; in fact, multiple cells may contain language
+declarations. The declaration takes effect when it is evaluated, and
+it affects the rest of the current cell and subsequent evaluations,
+until the kernel is restarted or until the next @litchar{#lang
+iracket/lang} declaration is evaluated.
+
+For example, the following declaration sets the initial environment to
+the exports of @racketmodname[racket/base] and sets the reader to
+Scribble's reader:
+@racketblock[
+#, @tt{#lang iracket/lang #:require racket/base #:reader scribble/reader}
+]
+
+
+@subsection[#:tag "hopeless"]{The Top Level (REPL) Is Hopeless}
+
+@(require (for-label (only-in racket/list [range r:range])))
+@(define (r:range) @racketlink[r:range]{@racketfont{range}})
+
+Due to the combination of Racket's macro system, its recursive top-level
+environment, and the fact that the REPL receives and processes forms one at a
+time, the Racket REPL occasionally produces unexpected behavior. Consider the
+following program:
+
+@racketblock[
+(code:comment "range : Real Real -> Real")
+(code:comment "Compute the size of the given interval.")
+(define (range x y)
+  (cond [(<= x y) (- y x)]
+        [else (code:comment "swap to normalize, try again")
+         (range y x)]))
+(range 5 10)
+(range 10 5)
+]
+
+When placed inside a @racket[#, @(hash-lang) #, @racketmodname[racket]] module,
+this code prints @racketresult[5] twice. But when run at the REPL (or in a
+@racketmodname[racket/load] module), the same code prints @racketresult[5] and
+then @racketresult['(5 6 7 8 9)]!
+
+The problem is that when the REPL receives the definition of
+@racketidfont{range}, it compiles the definition in an environment where
+@racketidfont{range} is still bound to @(r:range) from @racketmodname[racket]
+(which re-provides the exports of @racketmodname[racket/list]). So the
+``recursive'' call to @racketidfont{range} gets compiled as a call to
+@racketmodname[racket/list]'s @(r:range), not to the top-level
+@racketidfont{range} function that has not yet been defined.
+
+Racket's module system mainly avoids such problems by detecting defined names
+before expanding the right-hand sides of definitions.
+
+To avoid this problem, avoid redefining names.
+
+(An alternative is to put @racket[(define-syntaxes (#, @racketidfont{range})
+(values))] before the definition above. This form of @racket[define-syntaxes] is
+only allowed at the top level, and it changes @racketidfont{range} to resolve as
+a binding in the top-level environment without giving it a value.)
+
+@subsection[#:tag "iracket-lang"]{@racket[#, @(hash-lang) #, @racketmodname[iracket/lang]]}
+
+@defmodulelang[iracket/lang]
+
+In addition to being interpreted specially by the IRacket kernel (see
+@secref["lang"]), @racketmodname[iracket/lang] can be used as a language in
+Racket code. The purpose of the language is for testing how code should work in
+a Jupyter notebook; the @racketmodname[iracket/lang] language is not useful for
+developing normal Racket libraries and programs.
+
+As a language, it behaves similarly to @racketmodname[racket/load]. Like
+@racketmodname[racket/load], it evaluates body forms one by one in a top-level
+namespace. Unlike @racketmodname[racket/load], it allows controlling the reader,
+and it delays reading the module body until run time, so that if one expression
+dynamically changes the reader, it affects the reading of the rest of the module
+body.
+
+The following inconsistencies between Racket's interpretation of the
+@racketmodname[iracket/lang] language and IRacket's interpretation of
+a @litchar{#lang iracket/lang} declaration are known:
+@itemlist[
+
+@item{IRacket allows multiple @litchar{#lang iracket/lang} declarations in a
+notebook, but a Racket module does not (unless you change reader parameters, but
+then it still means something different).}
+
+@item{Notebook cell boundaries can affect reader behavior, because the reader
+stops at the end of each cell. Thus a module formed by simply concatenating cell
+contents might behave differently.}
+
+@item{When IRacket processes a @litchar{#lang iracket/lang} declaration, it does
+not reset parameters like @racket[current-readtable], @racket[read-accept-dot],
+etc. In contrast, Racket generally uses a fixed set of parameter values for
+reading modules (see @racketmodname[syntax/modread]).}
+
+]

--- a/iracket.scrbl
+++ b/iracket.scrbl
@@ -123,6 +123,8 @@ Scribble's reader:
 #, @tt{#lang iracket/lang #:require racket/base #:reader scribble/reader}
 ]
 
+@history[#:added "1.2"]
+
 
 @subsection[#:tag "hopeless"]{The Top Level (REPL) Is Hopeless}
 
@@ -205,3 +207,5 @@ etc. In contrast, Racket generally uses a fixed set of parameter values for
 reading modules (see @racketmodname[syntax/modread]).}
 
 ]
+
+@history[#:added "1.2"]

--- a/lang.rkt
+++ b/lang.rkt
@@ -1,0 +1,114 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         racket/match racket/port)
+(provide iracket-module-begin)
+
+;; Like racket/load ("The top level is hopeless!"), but
+;; - allows control over the initial language
+;; - allows control over the reader
+;; - read is delayed until run-time and incremental, so evaluation of
+;;   one term can affect reading of next term
+;; - interpreted specially by IRacket kernel: set sandbox namespace and reader
+
+;; Usage:
+;;
+;;   #lang iracket/lang <langopt> ...
+;;   where langopt =
+;;   | #:language <modulepath>
+;;   | #:reader <readerspec>
+;;
+;; Example:
+;;   #lang iracket/lang #:language racket
+;;   #lang iracket/lang #:reader ??? #:language scribble/doc
+
+(module reader racket/base
+  (require racket/port)
+  (provide (rename-out [-read read] [-read-syntax read-syntax]))
+  (define (-read in)
+    (syntax->datum (-read-syntax #f in)))
+  (define (-read-syntax src in)
+    (define-values (line col pos) (port-next-location in))
+    (define content (port->bytes in))
+    (define loc (list src line col pos #f))
+    (define mod-decl
+      `(module anonymous-module iracket/lang
+         (iracket-module-begin ,(datum->syntax #f content loc))))
+    (datum->syntax #f mod-decl)))
+
+(module config racket/base
+  (require racket/match racket/port)
+  (provide (all-defined-out))
+
+  (define (read-lang-config in)
+    (define (bad fmt . args) (apply error 'iracket/lang fmt args))
+    (define line0-in (open-input-bytes (read-bytes-line in 'any)))
+    (define args (port->list read line0-in))
+    (let loop ([args args] [config (hasheq)])
+      (match args
+        [(list* '#:require language rest)
+         (when (hash-has-key? config 'language)
+           (bad "duplicate #:language argument\n  got: ~.s" language))
+         (unless (module-path? language)
+           (bad "expected module path for language\n  got: ~.s" language))
+         (loop rest (hash-set config 'language language))]
+        [(list* '#:reader reader rest)
+         (when (hash-has-key? config 'reader)
+           (bad "duplicate #:reader argument\n  got: ~.s" reader))
+         (unless (module-path? reader)
+           (bad "expected module path for reader\n  got: ~.s" reader))
+         (loop rest (hash-set config 'reader reader))]
+        ['() config])))
+
+  (define (config:get-language config)
+    (hash-ref config 'language 'racket))
+
+  (define (config:get-read-syntax config ns)
+    (parameterize ((current-namespace ns))
+      (wrap-reader
+       (cond [(hash-ref config 'reader #f)
+              => (lambda (reader) (dynamic-require reader 'read-syntax))]
+             [else read-syntax]))))
+
+  (define (wrap-reader read-stx)
+    (lambda (src in) (read-stx src in))))
+
+(require 'config)
+
+;; ----------------------------------------
+
+(define-syntax (iracket-module-begin stx)
+  (syntax-case stx ()
+    [(_ cell ...)
+     (with-syntax ([the-namespace (datum->syntax stx 'the-namespace)])
+       #'(#%plain-module-begin
+          (provide the-namespace)
+          (define the-namespace
+            (iracket-run (#%variable-reference) (quote-syntax cell) ...))))]))
+
+(define (iracket-run varref stx . more-stxs)
+  (define src (syntax-source stx))
+  (define in (open-syntax-bytes-port stx))
+  (define config (read-lang-config in))
+  (define ns (variable-reference->empty-namespace varref))
+  (parameterize ((current-namespace ns))
+    (namespace-require (config:get-language config))
+    (define read-stx (config:get-read-syntax config ns))
+    (let loop ()
+      (define next (read-stx src in))
+      (unless (eof-object? next)
+        (call-with-values
+         (lambda () (eval-top next))
+         (lambda vs (for ([v (in-list vs)] #:unless (void? v)) (println v))))
+        (loop)))
+    ns))
+
+(define (open-syntax-bytes-port stx)
+  (define in (open-input-bytes (syntax-e stx)))
+  (port-count-lines! in)
+  (let ([l (syntax-line stx)] [c (syntax-column stx)] [p (syntax-position stx)])
+    (set-port-next-location! in l c p))
+  in)
+
+(define (eval-top e)
+  (call-with-continuation-prompt
+   (lambda () (eval e))))


### PR DESCRIPTION
This PR allows notebooks to switch languages (both initial environment and reader) for subsequent evaluations.

Compared to #2 and #5, this PR
- does not require changes to registration of kernel with Jupyter
- allows language configuration to be done at the notebook level
- makes the inconsistency between the `#lang` (module-based) treatment of languages and the top-level/REPL treatment explicit
